### PR TITLE
Fix zero temperature state and add cooldown function

### DIFF
--- a/fan_control.sh
+++ b/fan_control.sh
@@ -247,7 +247,7 @@ while true; do
         pwmValue=$pwmDrive
         log "Setting PWM based on Drive temperature"
         cooldown=$COOLDOWN_MAX
-    elif (( "$pwmNVMe" > "pwmDrive" )) && (( "$pwmNVMe" > "$pwmCPU" )); then
+    elif (( "$pwmNVMe" > "$pwmDrive" )) && (( "$pwmNVMe" > "$pwmCPU" )); then
         pwmValue=$pwmNVMe
         log "Setting PWM based on NVMe temperature"
         cooldown=$COOLDOWN_MAX

--- a/fan_control.sh
+++ b/fan_control.sh
@@ -159,6 +159,9 @@ if [ ! -e "$fanSpeedDir" ] || [ ! -e "$fanRpmDir" ] || [ ! -e "$cpuTempDir" ]; t
     exit 1
 fi
 
+# Initialise cooldown.
+cooldown=0
+
 # Infinite loop to monitor and control fan speed based on the highest temperature
 while true; do
     # Read the current fan speed, fan RPM, and CPU temperature
@@ -227,15 +230,30 @@ while true; do
     pwmNVMe=$(calculate_pwm "$maxNVMe" "$NVME_LOW_TEMP" "$NVME_HIGH_TEMP")
 
     # Determine the highest PWM value
-    if [ "$pwmCPU" -ge "$pwmDrive" ] && [ "$pwmCPU" -ge "$pwmNVMe" ]; then
+    if (( "$pwmCPU" + "$pwmDrive" + "$pwmNVMe" == 0 )); then
+        if (( "$cooldown" > 0 )); then
+            pwmValue=$MIN_PWM
+            log "Setting PWM to MIN because of cooldown ($cooldown interval(s) left)"
+            cooldown=$((cooldown - 1))
+        else
+            pwmValue=0
+            log "No MIN thresholds met and no cooldown, fan off."
+        fi
+    elif (( "$pwmCPU" > "$pwmDrive" )) && (( "$pwmCPU" > "$pwmNVMe" )); then
         pwmValue=$pwmCPU
         log "Setting PWM based on CPU temperature"
-    elif [ "$pwmDrive" -ge "$pwmCPU" ] && [ "$pwmDrive" -ge "$pwmNVMe" ]; then
+        cooldown=$COOLDOWN_MAX
+    elif (( "$pwmDrive" > "$pwmCPU" )) && (( "$pwmDrive" > "$pwmNVMe" )); then
         pwmValue=$pwmDrive
         log "Setting PWM based on Drive temperature"
-    else
+        cooldown=$COOLDOWN_MAX
+    elif (( "$pwmNVMe" > "pwmDrive" )) && (( "$pwmNVMe" > "$pwmCPU" )); then
         pwmValue=$pwmNVMe
         log "Setting PWM based on NVMe temperature"
+        cooldown=$COOLDOWN_MAX
+    else
+        pwmValue=$MAX_PWM
+        log_error "Unknown state, turning fan on. Check your configuration."
     fi
 
     # Set the fan speed to the highest PWM value


### PR DESCRIPTION
In short; I fixed unintentional behaviour in the "Determine highest PWM value" section and added a cooldown function that keeps the fan on for a few intervals after going below threshold. Read on for full details.

Running this script myself I noticed that in the "no thresholds met" state it would repeatedly log that it set temperature based on CPU. The condition check uses -ge (greater or equal to) instead of -gt (strictly greater than), which is always true when zero is compared against itself. Despite this, it works anyway because calculate_pwm would set pwmCPU to zero if it was below threshold, functionally turning off the fan.

It functions, yes, but out of coincidence more than intent. So I adjusted the conditions to check "greater than", instead of "greater than or equal" and added a missing check for pwmNVMe. But this introduces a minor problem, now whenever all pwm variables are below the threshold, the script uses a lot of CPU cycles calculating each pwm variable against each other when it's not strictly necessary. So I added an initial check for "if sum of all pwm variables is zero, then no threshold is met and the fan should be off". In addition, I also changed the check from conditional to arithmetic to save some more CPU cycles/make it easier to read.

I also noticed another minor problem, with this implementation it was common for the fan to oscillate between on and off as it wavered above and below the threshold. With a 3 second interval for instance, it could mean the fan turns on for 3 seconds, cools down enough to be below threshold to turn off the next 3 seconds, then turns back on again as it heats up. The cooldown functions as a way to not be as oscillating without just increasing the interval, it will keep the fan on min for a few intervals after it's below threshold.

I also added a final else function, for unknown conditions. This shouldn't be reached, but in case it is then the backup action is to turn the fan on max, following computer case conventions for "if the software is bugged and does not behave as expected, turn on the fans to max to avoid overheating".

There are other optimisations that could be made to all of this, but I wanted to keep the same sort of structure the original script had.